### PR TITLE
fix: migrations file names

### DIFF
--- a/modules/account/migrations/1635083521538-init_accounts.ts
+++ b/modules/account/migrations/1635083521538-init_accounts.ts
@@ -1,6 +1,6 @@
 import { PoolClient } from "pg";
 export default {
-  name: "2021-10-24T13:52:01.538Z-init_accounts",
+  name: "1635083521538-init_accounts",
   up: async (db: PoolClient) => {
     await db.query(`CREATE TABLE IF NOT EXISTS accounts (
       id uuid PRIMARY KEY,

--- a/modules/account/migrations/1635356662849-account_tokens.ts
+++ b/modules/account/migrations/1635356662849-account_tokens.ts
@@ -1,6 +1,6 @@
 import { PoolClient } from "pg";
 export default {
-  name: "2021-10-27T17:44:22.849Z-account_tokens",
+  name: "1635356662849-account_tokens",
   up: async (db: PoolClient) => {
     await db.query(`CREATE TABLE IF NOT EXISTS account_tokens (
       token uuid PRIMARY KEY,

--- a/modules/account/migrations/1635522608027-permissions.ts
+++ b/modules/account/migrations/1635522608027-permissions.ts
@@ -1,6 +1,6 @@
 import { PoolClient } from "pg";
 export default {
-  name: "2021-10-29T15:50:08.027Z-permissions",
+  name: "1635522608027-permissions",
   up: async (db: PoolClient) => {
     await db.query(`CREATE TABLE IF NOT EXISTS account_permissions (
       account_id uuid NOT NULL,

--- a/modules/account/migrations/index.ts
+++ b/modules/account/migrations/index.ts
@@ -1,8 +1,4 @@
-import migration_1 from './2021-10-24T13:52:01.538Z-init_accounts'
-import migration_2 from './2021-10-27T17:44:22.849Z-account_tokens'
-import migration_3 from './2021-10-29T15:50:08.027Z-permissions'
-export default [
-migration_1,
-migration_2,
-migration_3
-]
+import migration_1 from "./1635083521538-init_accounts";
+import migration_2 from "./1635356662849-account_tokens";
+import migration_3 from "./1635522608027-permissions";
+export default [migration_1, migration_2, migration_3];

--- a/modules/content/migrations/1635084231501-init_content.ts
+++ b/modules/content/migrations/1635084231501-init_content.ts
@@ -1,6 +1,6 @@
 import { PoolClient } from "pg";
 export default {
-  name: "2021-10-24T14:03:51.501Z-init_content",
+  name: "1635084231501-init_content",
   up: async (db: PoolClient) => {
     await db.query(`CREATE EXTENSION IF NOT EXISTS ltree`);
     await db.query(`CREATE TABLE IF NOT EXISTS content (

--- a/modules/content/migrations/1635611069536-add_page_params.ts
+++ b/modules/content/migrations/1635611069536-add_page_params.ts
@@ -1,6 +1,6 @@
 import { PoolClient } from "pg";
 export default {
-  name: "2021-10-30T16:24:29.536Z-add_page_params",
+  name: "1635611069536-add_page_params",
   up: async (db: PoolClient) => {
     await db.query(`ALTER TABLE content ADD COLUMN parameters jsonb`);
   },

--- a/modules/content/migrations/1635665297908-add_page_title.ts
+++ b/modules/content/migrations/1635665297908-add_page_title.ts
@@ -1,6 +1,6 @@
 import { PoolClient } from "pg";
 export default {
-  name: "2021-10-31T07:28:17.908Z-add_page_title",
+  name: "1635665297908-add_page_title",
   up: async (db: PoolClient) => {
     await db.query(`ALTER TABLE content ADD COLUMN title text NOT NULL`);
   },

--- a/modules/content/migrations/index.ts
+++ b/modules/content/migrations/index.ts
@@ -1,8 +1,4 @@
-import migration_1 from './2021-10-24T14:03:51.501Z-init_content'
-import migration_2 from './2021-10-30T16:24:29.536Z-add_page_params'
-import migration_3 from './2021-10-31T07:28:17.908Z-add_page_title'
-export default [
-migration_1,
-migration_2,
-migration_3
-]
+import migration_1 from "./1635084231501-init_content";
+import migration_2 from "./1635611069536-add_page_params";
+import migration_3 from "./1635665297908-add_page_title";
+export default [migration_1, migration_2, migration_3];

--- a/tools/migrate.ts
+++ b/tools/migrate.ts
@@ -8,6 +8,7 @@ const [_, __, command, ...args] = process.argv;
 
 const commands = {
   create: async (mod: string, name: string) => {
+    if (!name) throw new Error("Migration name is required");
     const relativeDir = path.join("../modules", mod, "migrations");
     const dirPath = path.join(__dirname, relativeDir);
     try {
@@ -15,7 +16,7 @@ const commands = {
     } catch (err) {
       console.error(err);
     }
-    const nameWithTimestamp = `${new Date().toISOString()}-${name}`;
+    const nameWithTimestamp = `${Date.now()}_${name}`;
     const fileName = `${nameWithTimestamp}.ts`;
 
     await fs.writeFile(


### PR DESCRIPTION
- Replaces ISO timestamp with Unix timestamp in migration names to avoid issues on Windows machines
- Prevents `...-undefined` files from being created

Closes #356 